### PR TITLE
add topic settings and remove default expiration

### DIFF
--- a/lib/apns.js
+++ b/lib/apns.js
@@ -102,6 +102,7 @@ class APNS extends EventEmitter {
     this._key = options.key;
     this._cert = options.cert;
     this._signingKey = options.signingKey;
+    this._defaultTopic = options.defaultTopic;
     this._concurrency = options.concurrency || CONCURRENCY;
     this._client = new HTTP2Client(options.host || HOST, options.port || PORT);
     this._interval = setInterval(() => this._resetSigningToken(), RESET_TOKEN_INTERVAL).unref();
@@ -138,9 +139,20 @@ class APNS extends EventEmitter {
       path: `/${API_VERSION}/device/${encodeURIComponent(notification.deviceToken)}`,
       headers: {
         'apns-priority': notification.priority,
-        'apns-expiration': parseInt(notification.expiration / 1000)
       }
     };
+
+    if (notification.expiration) {
+      options.headers['apns-expiration'] = parseInt(notification.expiration / 1000);
+    }
+
+    if (this._defaultTopic) {
+      options.headers['apns-topic'] = this._defaultTopic;
+    }
+
+    if (notification.topic) {
+      options.headers['apns-topic'] = notification.topic;
+    }
 
     if (this._cert) {
       options.cert = this._cert;

--- a/lib/notifications/notification.js
+++ b/lib/notifications/notification.js
@@ -29,6 +29,7 @@ class Notification {
    * @param {Object} [options.data]
    * @param {Boolean} [options.contentAvailable]
    * @param {Number} [options.priority]
+   * @param {String} [options.topic]
    * @param {Object} [options.aps] - override all setters
    */
   constructor(deviceToken, options) {
@@ -53,10 +54,16 @@ class Notification {
 
   /**
    * @prop {Number} expiration
-   * @default 24 hours from now
    */
   get expiration() {
-    return this._options.expiration || (Date.now() + (24 * 60 * 60 * 1000));
+    return this._options.expiration;
+  }
+
+  /**
+   * @prop {String} topic
+   */
+  get topic() {
+    return this._options.topic;
   }
 
   /**


### PR DESCRIPTION
When a certificate includes multiple topics the header value `apns-topic` must be specified in the request.

Apple documentation
https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/APNsProviderAPI.html
> The topic of the remote notification, which is typically the bundle ID for your app. The certificate you create in Member Center must include the capability for this topic.
> If your certificate includes multiple topics, you must specify a value for this header.
> If you omit this header and your APNs certificate does not specify multiple topics, the APNs server uses the certificate’s Subject as the default topic.