### PR TITLE
Add Type Definitions for TypeScript

### DIFF
--- a/lib/apns.d.ts
+++ b/lib/apns.d.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from "events"
+
+declare class APNS extends EventEmitter {
+  constructor(options: APNS.Options)
+  send(notification: APNS.Notification): Promise<APNS.Notification>
+  send(notifications: APNS.Notification[]): Promise<APNS.Notification[]>
+}
+
+declare namespace APNS {
+  export interface Options {
+    team: string
+    keyId: string
+    signingKey: string
+    defaultTopic?: string
+    host?: string
+    port?: number
+  }
+
+  export interface NotificationAlert {
+    title: string
+    body: string
+  }
+
+  export interface NotificationOptions {
+    alert?: string | NotificationAlert
+    badge?: number
+    sound?: string
+    category?: string
+    data?: object
+    contentAvailable?: boolean
+    priority?: number
+    aps?: object
+  }
+
+  export class Notification {
+    constructor(deviceToken: string, options?: NotificationOptions)
+    static readonly priority: Notification.Priority
+    readonly deviceToken: string
+    readonly priority: number
+    readonly expiration: number
+    readonly topic: string
+    readonly collapseId: string
+  }
+
+  export namespace Notification {
+    export interface Priority {
+      immediate: number
+      throttled: number
+    }
+  }
+
+  export class BasicNotification extends Notification {
+    constructor(deviceToken: string, message: string, options?: NotificationOptions)
+  }
+
+  export class SilentNotification extends Notification {
+    constructor(deviceToken: string, options?: NotificationOptions)
+  }
+
+  export interface Errors {
+    badCertificate: string
+    badCertificateEnvironment: string
+    badCollapseId: string
+    badDeviceToken: string
+    badExpirationDate: string
+    badMessageId: string
+    badPath: string
+    badPriority: string
+    badTopic: string
+    deviceTokenNotForTopic: string
+    duplicateHeaders: string
+    error: string
+    expiredProviderToken: string
+    forbidden: string
+    idleTimeout: string
+    internalServerError: string
+    invalidProviderToken: string
+    invalidSigningKey: string
+    methodNotAllowed: string
+    missingDeviceToken: string
+    missingTopic: string
+    payloadEmpty: string
+    payloadTooLarge: string
+    serviceUnavailable: string
+    shutdown: string
+    tooManyRequests: string
+    topicDisallowed: string
+    unknownError: string
+    unregistered: string
+  }
+  
+  export const errors: Errors
+}
+
+export = APNS

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Node client for connecting to Apple's Push Notification Service using the new HTTP/2 protocol with JSON web tokens.",
   "author": "Andrew Barba <abarba.77@gmail.com>",
   "main": "lib/apns.js",
+  "types": "lib/apns.d.ts",
   "license": "MIT",
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
It's still pretty rough around the edges but it should work.

The following TypeScript:

```ts
import * as APNS from "apns2"
const { Notification } = APNS

let client = new APNS({
  team: "",
  signingKey: "",
  keyId: ""
})

let priority = Notification.priority.immediate
client.send([new Notification("")])
client.send(new Notification(""))
```

Produces the following JavaScript:

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
const APNS = require("apns2");
const { Notification } = APNS;
let client = new APNS({
    team: "",
    signingKey: "",
    keyId: ""
});
let priority = Notification.priority.immediate;
client.send([new Notification("")]);
client.send(new Notification(""));
```

Which looks pretty much right to me. `import APNS = require("apns2")` also works.

Resolves #12.