### PR TITLE
Adds support for passing a thread-id in the aps payload

### DIFF
--- a/lib/notifications/notification.js
+++ b/lib/notifications/notification.js
@@ -29,6 +29,7 @@ class Notification {
    * @param {Number} [options.priority]
    * @param {String} [options.topic]
    * @param {String} [options.collapseId]
+   * @param {String} [options.threadId]
    * @param {Object} [options.aps] - override all setters
    */
   constructor(deviceToken, options) {
@@ -105,6 +106,11 @@ class Notification {
     // Check for badge
     if (_.isNumber(this._options.badge)) {
       result.aps.badge = this._options.badge
+    }
+
+    // Check for threadId
+    if (_.isString(this._options.threadId)) {
+      result.aps[`thread-id`] = this._options.threadId
     }
 
     // Add optional message data

--- a/test/test.js
+++ b/test/test.js
@@ -108,6 +108,18 @@ describe('apns', () => {
       return apns.send(notification)
     })
 
+    it('should send a notification with a thread-id', async () => {
+      let notification = new Notification(deviceToken, {
+        aps: {
+          alert: {
+            body: `Hello, Tablelist`
+          }
+        },
+        threadId: `hello`
+      })
+      return apns.send(notification)
+    })
+
     it('should send both notifications', async () => {
       let basicNotification = new BasicNotification(deviceToken, `Hello, Multiple`)
       let silentNotification = new SilentNotification(deviceToken)


### PR DESCRIPTION
See this issue here:
https://github.com/AndrewBarba/apns2/issues/19

Unfortunately, I can't run the tests (I'm guessing the token.p8 file is added by the build server?)

```
  1) apns
       signing token
         "before all" hook:
     Error: ENOENT: no such file or directory, open '/Users/gmelton/work/apns2/test/certs/token.p8'
      at Object.openSync (fs.js:451:3)
      at Object.readFileSync (fs.js:351:35)
      at Context.before (test/test.js:68:14)
```