### PR TITLE
Fix typo in APNS destroy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ export class APNS extends EventEmitter {
   constructor(options: APNSOptions)
   send(notification: Notification): Promise<Notification>
   sendMany(notifications: Notification[]): Promise<Notification[]>
-  destroy(): Promise<Void>
+  destroy(): Promise<void>
 }
 
 export class Notification {


### PR DESCRIPTION
`Void` -> `void`