### PR TITLE
Added Priority.low option. Avoid send header Priority.immediate (default)

### DIFF
--- a/src/apns.ts
+++ b/src/apns.ts
@@ -2,7 +2,7 @@ import { sign, Secret } from 'jsonwebtoken'
 import { EventEmitter } from 'events'
 import { fetch, RequestInit, Response } from 'fetch-http2'
 import { Errors } from './errors'
-import { Notification } from './notifications/notification'
+import { Notification, Priority } from './notifications/notification'
 
 // APNS version
 const API_VERSION = 3
@@ -73,11 +73,14 @@ export class ApnsClient extends EventEmitter {
       headers: {
         authorization: `bearer ${this._getSigningToken()}`,
         'apns-push-type': notification.pushType,
-        'apns-priority': notification.priority.toString(),
         'apns-topic': notification.options.topic ?? this.defaultTopic
       },
       body: JSON.stringify(notification.buildApnsOptions()),
       keepAlive: 5000
+    }
+
+    if (notification.priority !== Priority.immediate) {
+      options.headers!['apns-priority'] = notification.priority.toString();
     }
 
     if (notification.options.expiration) {

--- a/src/apns.ts
+++ b/src/apns.ts
@@ -80,7 +80,7 @@ export class ApnsClient extends EventEmitter {
     }
 
     if (notification.priority !== Priority.immediate) {
-      options.headers!['apns-priority'] = notification.priority.toString();
+      options.headers!['apns-priority'] = notification.priority.toString()
     }
 
     if (notification.options.expiration) {

--- a/src/notifications/constants/priority.ts
+++ b/src/notifications/constants/priority.ts
@@ -1,4 +1,5 @@
 export enum Priority {
   immediate = 10,
-  throttled = 5
+  throttled = 5,
+  low = 1
 }


### PR DESCRIPTION
Hello, I hope all is well. Here are 2 improvements:

1. The header `apns-priority` is optional, and the default is **10** (immediate). So, we can avoid sending it when it is the default to avoid unnecessary data transfer.

2. I added the option `Priority.low` with value of **1**, as is mentioned in the Apple documentation. If you have a better name instead of `low` I'm open to suggestions.

Source: Apple Documentation - https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#4294479

---
Note: This could be done with the header `apns-push-type` too, but Apple says that it is required for some OS and **recommended** for others. So I preferred not to change it.